### PR TITLE
HAS-131: select ExceptionProcessor by exception hierarchy, not exact class

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,13 @@ GlobalErrorExceptionHandler globalErrorExceptionHandler(
 A custom processor implements `ExceptionProcessor` and maps an exception to an
 `Errors` object (HTTP status + list of `ErrorMessage`).
 
+Processor selection is hierarchy-aware: an exception matches the processor registered
+for its exact class or, failing that, for its most specific registered supertype (e.g.
+`MissingRequestValueException` is handled by the `ServerWebInputException` processor).
+Framework `ResponseStatusException`s without a more specific registration (unmatched
+route → 404, unsupported method → 405, …) keep their own status; exceptions with no
+matching registration at all fall back to the default processor (HTTP 500).
+
 ### Info endpoint
 
 `InfoController` (active in web applications only) exposes `GET /info` with the

--- a/src/main/java/cloud/cholewa/commons/error/GlobalErrorExceptionHandler.java
+++ b/src/main/java/cloud/cholewa/commons/error/GlobalErrorExceptionHandler.java
@@ -8,6 +8,7 @@ import cloud.cholewa.commons.error.processor.DuplicateKeyExceptionProcessor;
 import cloud.cholewa.commons.error.processor.ExceptionProcessor;
 import cloud.cholewa.commons.error.processor.NoSuchElementProcessor;
 import cloud.cholewa.commons.error.processor.NotImplementedExceptionProcessor;
+import cloud.cholewa.commons.error.processor.ResponseStatusExceptionProcessor;
 import cloud.cholewa.commons.error.processor.ServerWebInputExceptionProcessor;
 import cloud.cholewa.commons.error.processor.WebClientResponseExceptionProcessor;
 import cloud.cholewa.commons.error.processor.WebExchangeBindExceptionProcessor;
@@ -29,6 +30,7 @@ import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.RouterFunctions;
 import org.springframework.web.reactive.function.server.ServerRequest;
 import org.springframework.web.reactive.function.server.ServerResponse;
+import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.server.ServerWebInputException;
 import org.yaml.snakeyaml.constructor.DuplicateKeyException;
 import reactor.core.publisher.Mono;
@@ -59,6 +61,7 @@ public class GlobalErrorExceptionHandler extends AbstractErrorWebExceptionHandle
             Map.entry(ConstraintViolationException.class, new ConstraintViolationExceptionProcessor()),
             Map.entry(DuplicateKeyException.class, new DuplicateKeyExceptionProcessor()),
             Map.entry(NotImplementedException.class, new NotImplementedExceptionProcessor()),
+            Map.entry(ResponseStatusException.class, new ResponseStatusExceptionProcessor()),
             Map.entry(ServerWebInputException.class, new ServerWebInputExceptionProcessor()),
             Map.entry(WebClientResponseException.class, new WebClientResponseExceptionProcessor()),
             Map.entry(WebExchangeBindException.class, new WebExchangeBindExceptionProcessor()),
@@ -71,7 +74,7 @@ public class GlobalErrorExceptionHandler extends AbstractErrorWebExceptionHandle
     ) {
         this.processors = Stream.of(this.processors, processors)
             .flatMap(map -> map.entrySet().stream())
-            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (builtIn, custom) -> custom));
 
         return this;
     }
@@ -85,14 +88,27 @@ public class GlobalErrorExceptionHandler extends AbstractErrorWebExceptionHandle
     }
 
     Mono<ServerResponse> renderErrorResponse(final ServerRequest request) {
-        Throwable throwable = getError(request);
+        Throwable throwable = Objects.requireNonNull(getError(request));
 
-        Errors errors = processors.getOrDefault(Objects.requireNonNull(throwable).getClass(), defaultExceptionProcessor)
-            .apply(getError(request));
+        Errors errors = resolveProcessor(throwable).apply(throwable);
 
         return ServerResponse
             .status(errors.getHttpStatus())
             .body(BodyInserters.fromValue(errors));
+    }
+
+    ExceptionProcessor resolveProcessor(final Throwable throwable) {
+        ExceptionProcessor exactMatch = processors.get(throwable.getClass());
+
+        if (exactMatch != null) {
+            return exactMatch;
+        }
+
+        return processors.keySet().stream()
+            .filter(type -> type.isInstance(throwable))
+            .reduce((first, second) -> first.isAssignableFrom(second) ? second : first)
+            .map(processors::get)
+            .orElse(defaultExceptionProcessor);
     }
 
     /*

--- a/src/main/java/cloud/cholewa/commons/error/processor/DefaultExceptionProcessor.java
+++ b/src/main/java/cloud/cholewa/commons/error/processor/DefaultExceptionProcessor.java
@@ -13,11 +13,7 @@ public class DefaultExceptionProcessor implements ExceptionProcessor {
     @Override
     public Errors apply(final Throwable throwable) {
 
-        log.error(
-            "Generic exception [{}]: {}",
-            throwable.getClass().getName(),
-            throwable.getLocalizedMessage()
-        );
+        log.error("Generic exception [{}]", throwable.getClass().getSimpleName(), throwable);
 
         return Errors.builder()
             .httpStatus(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/src/main/java/cloud/cholewa/commons/error/processor/ResponseStatusExceptionProcessor.java
+++ b/src/main/java/cloud/cholewa/commons/error/processor/ResponseStatusExceptionProcessor.java
@@ -1,0 +1,29 @@
+package cloud.cholewa.commons.error.processor;
+
+import cloud.cholewa.commons.error.model.ErrorMessage;
+import cloud.cholewa.commons.error.model.Errors;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Collections;
+import java.util.Optional;
+
+public class ResponseStatusExceptionProcessor implements ExceptionProcessor {
+
+    @Override
+    public Errors apply(final Throwable throwable) {
+        final ResponseStatusException exception = (ResponseStatusException) throwable;
+
+        final HttpStatus httpStatus = Optional.ofNullable(HttpStatus.resolve(exception.getStatusCode().value()))
+            .orElse(HttpStatus.INTERNAL_SERVER_ERROR);
+
+        return Errors.builder()
+            .httpStatus(httpStatus)
+            .errors(Collections.singleton(
+                ErrorMessage.builder()
+                    .message(Optional.ofNullable(exception.getReason()).orElse(httpStatus.getReasonPhrase()))
+                    .build()
+            ))
+            .build();
+    }
+}

--- a/src/main/java/cloud/cholewa/commons/error/processor/ServerWebInputExceptionProcessor.java
+++ b/src/main/java/cloud/cholewa/commons/error/processor/ServerWebInputExceptionProcessor.java
@@ -8,67 +8,57 @@ import org.springframework.web.server.ServerWebInputException;
 
 import java.util.Collections;
 import java.util.Optional;
-import java.util.Set;
 
 public class ServerWebInputExceptionProcessor implements ExceptionProcessor {
 
+    private static final int MAX_CAUSE_DEPTH = 16;
+
     @Override
     public Errors apply(final Throwable throwable) {
-        final Throwable cause = ((ServerWebInputException) throwable).getMostSpecificCause();
+        final ServerWebInputException exception = (ServerWebInputException) throwable;
 
-        ErrorMessage errorMessage = ErrorMessage.builder()
-            .message("Unknown type of ServerWebInputException")
+        return Errors.builder()
+            .httpStatus(HttpStatus.BAD_REQUEST)
+            .errors(Collections.singleton(buildErrorMessage(exception)))
             .build();
+    }
 
-        if (cause instanceof ServerWebInputException serverWebInputException) {
-            return Errors.builder()
-                .httpStatus(HttpStatus.BAD_REQUEST)
-                .errors(Collections.singleton(
-                    handleServerWebInputException(serverWebInputException, errorMessage)
-                ))
-                .build();
-        } else if (cause instanceof DecodingException) {
-            return Errors.builder()
-                .httpStatus(HttpStatus.BAD_REQUEST)
-                .errors(handleDecodingException(cause, errorMessage))
-                .build();
-        } else {
-            return Errors.builder()
-                .httpStatus(HttpStatus.BAD_REQUEST)
-                .errors(handleUnknownTypeOfServerWebInputException(cause, errorMessage))
+    private ErrorMessage buildErrorMessage(final ServerWebInputException exception) {
+        return findDecodingCause(exception)
+            .map(this::decodingErrorMessage)
+            .orElseGet(() -> inputErrorMessage(exception));
+    }
+
+    private ErrorMessage decodingErrorMessage(final DecodingException decodingException) {
+        if (decodingException.getCause() == null) {
+            return ErrorMessage.builder()
+                .message("Missing request body")
                 .build();
         }
+
+        return ErrorMessage.builder()
+            .message("Malformed request body")
+            .details(decodingException.getMostSpecificCause().getMessage())
+            .build();
     }
 
-    private ErrorMessage handleServerWebInputException(
-        final ServerWebInputException ex,
-        final ErrorMessage errorMessage
-    ) {
-        return Optional.ofNullable(ex.getMethodParameter())
-            .map(methodParameter -> {
-                errorMessage.setMessage("aaaa");
-                errorMessage.setDetails("det");
-                return errorMessage;
-            })
-            .orElse(errorMessage);
+    private ErrorMessage inputErrorMessage(final ServerWebInputException exception) {
+        return ErrorMessage.builder()
+            .message(Optional.ofNullable(exception.getReason()).orElse("Invalid request input"))
+            .details(exception.getCause() == null ? null : exception.getMostSpecificCause().getMessage())
+            .build();
     }
 
-    private Set<ErrorMessage> handleUnknownTypeOfServerWebInputException(
-        final Throwable throwable,
-        final ErrorMessage errorMessage
-    ) {
-        errorMessage.setDetails(throwable.fillInStackTrace().toString());
+    private Optional<DecodingException> findDecodingCause(final Throwable throwable) {
+        Throwable current = throwable;
+        int depth = 0;
 
-        return Collections.singleton(errorMessage);
-    }
+        while (current != null && !(current instanceof DecodingException) && depth++ < MAX_CAUSE_DEPTH) {
+            current = current.getCause();
+        }
 
-    private Set<ErrorMessage> handleDecodingException(
-        final Throwable throwable,
-        final ErrorMessage errorMessage
-    ) {
-        errorMessage.setMessage("Missing request body");
-        errorMessage.setDetails(throwable.fillInStackTrace().toString());
-
-        return Collections.singleton(errorMessage);
+        return current instanceof DecodingException decodingException
+            ? Optional.of(decodingException)
+            : Optional.empty();
     }
 }

--- a/src/main/java/cloud/cholewa/commons/error/processor/WebClientResponseExceptionProcessor.java
+++ b/src/main/java/cloud/cholewa/commons/error/processor/WebClientResponseExceptionProcessor.java
@@ -3,9 +3,11 @@ package cloud.cholewa.commons.error.processor;
 import cloud.cholewa.commons.error.model.ErrorMessage;
 import cloud.cholewa.commons.error.model.Errors;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 import java.util.Collections;
+import java.util.Optional;
 
 @Slf4j
 public class WebClientResponseExceptionProcessor implements ExceptionProcessor {
@@ -21,6 +23,10 @@ public class WebClientResponseExceptionProcessor implements ExceptionProcessor {
         );
 
         return Errors.builder()
+            .httpStatus(
+                Optional.ofNullable(HttpStatus.resolve(webClientResponseException.getStatusCode().value()))
+                    .orElse(HttpStatus.INTERNAL_SERVER_ERROR)
+            )
             .errors(
                 Collections.singleton(
                     ErrorMessage.builder()

--- a/src/test/java/cloud/cholewa/commons/error/GlobalErrorExceptionHandlerIntegrationTest.java
+++ b/src/test/java/cloud/cholewa/commons/error/GlobalErrorExceptionHandlerIntegrationTest.java
@@ -1,0 +1,163 @@
+package cloud.cholewa.commons.error;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.web.WebProperties;
+import org.springframework.boot.webflux.error.ErrorAttributes;
+import org.springframework.boot.webflux.test.autoconfigure.WebFluxTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.codec.ServerCodecConfigurer;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import org.springframework.web.server.ServerWebInputException;
+
+@WebFluxTest(controllers = GlobalErrorExceptionHandlerIntegrationTest.TestController.class)
+@Import({
+    GlobalErrorExceptionHandlerIntegrationTest.TestController.class,
+    GlobalErrorExceptionHandlerIntegrationTest.TestConfig.class
+})
+class GlobalErrorExceptionHandlerIntegrationTest {
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @RestController
+    static class TestController {
+
+        @GetMapping("/required-param")
+        String requiredParam(@RequestParam final String value) {
+            return value;
+        }
+
+        @GetMapping("/bad-input")
+        String badInput() {
+            throw new ServerWebInputException("bad input");
+        }
+
+        @GetMapping("/unhandled")
+        String unhandled() {
+            throw new IllegalStateException("boom");
+        }
+
+        @PostMapping("/body")
+        String body(@RequestBody final TestPayload payload) {
+            return payload.name();
+        }
+
+        @GetMapping("/typed/{id}")
+        int typed(@PathVariable final int id) {
+            return id;
+        }
+
+        @GetMapping("/downstream")
+        String downstream() {
+            throw WebClientResponseException.create(404, "Not Found", HttpHeaders.EMPTY, new byte[0], null);
+        }
+    }
+
+    record TestPayload(String name) {
+    }
+
+    @Configuration
+    static class TestConfig {
+
+        @Bean
+        GlobalErrorExceptionHandler globalErrorExceptionHandler(
+            final ErrorAttributes errorAttributes,
+            final ApplicationContext applicationContext,
+            final ServerCodecConfigurer configurer
+        ) {
+            return new GlobalErrorExceptionHandler(
+                errorAttributes,
+                new WebProperties.Resources(),
+                applicationContext,
+                configurer
+            );
+        }
+    }
+
+    @Test
+    void should_return_bad_request_when_required_param_is_missing() {
+        webTestClient.get().uri("/required-param")
+            .exchange()
+            .expectStatus().isBadRequest()
+            .expectBody().jsonPath("$.errors[0].message")
+            .isEqualTo("Required query parameter 'value' is not present.");
+    }
+
+    @Test
+    void should_return_bad_request_for_server_web_input_exception() {
+        webTestClient.get().uri("/bad-input")
+            .exchange()
+            .expectStatus().isBadRequest()
+            .expectBody().jsonPath("$.errors[0].message").isEqualTo("bad input");
+    }
+
+    @Test
+    void should_return_bad_request_when_body_is_missing() {
+        webTestClient.post().uri("/body")
+            .header("Content-Type", "application/json")
+            .exchange()
+            .expectStatus().isBadRequest()
+            .expectBody().jsonPath("$.errors[0].message").isEqualTo("Missing request body");
+    }
+
+    @Test
+    void should_return_bad_request_when_body_is_malformed() {
+        webTestClient.post().uri("/body")
+            .header("Content-Type", "application/json")
+            .bodyValue("{not-json")
+            .exchange()
+            .expectStatus().isBadRequest()
+            .expectBody().jsonPath("$.errors[0].message").isEqualTo("Malformed request body");
+    }
+
+    @Test
+    void should_return_bad_request_when_path_variable_type_mismatches() {
+        webTestClient.get().uri("/typed/abc")
+            .exchange()
+            .expectStatus().isBadRequest()
+            .expectBody()
+            .jsonPath("$.errors[0].message").isEqualTo("Type mismatch.")
+            .jsonPath("$.errors[0].details").isEqualTo("For input string: \"abc\"");
+    }
+
+    @Test
+    void should_return_not_found_for_unmapped_route() {
+        webTestClient.get().uri("/nonexistent")
+            .exchange()
+            .expectStatus().isNotFound();
+    }
+
+    @Test
+    void should_return_method_not_allowed_for_wrong_http_method() {
+        webTestClient.post().uri("/bad-input")
+            .exchange()
+            .expectStatus().isEqualTo(HttpStatus.METHOD_NOT_ALLOWED);
+    }
+
+    @Test
+    void should_propagate_downstream_status_for_web_client_response_exception_subclass() {
+        webTestClient.get().uri("/downstream")
+            .exchange()
+            .expectStatus().isNotFound();
+    }
+
+    @Test
+    void should_return_internal_server_error_for_unhandled_exception() {
+        webTestClient.get().uri("/unhandled")
+            .exchange()
+            .expectStatus().is5xxServerError();
+    }
+}

--- a/src/test/java/cloud/cholewa/commons/error/GlobalErrorExceptionHandlerTest.java
+++ b/src/test/java/cloud/cholewa/commons/error/GlobalErrorExceptionHandlerTest.java
@@ -1,0 +1,83 @@
+package cloud.cholewa.commons.error;
+
+import cloud.cholewa.commons.error.model.Errors;
+import cloud.cholewa.commons.error.processor.DefaultExceptionProcessor;
+import cloud.cholewa.commons.error.processor.ExceptionProcessor;
+import cloud.cholewa.commons.error.processor.ResponseStatusExceptionProcessor;
+import cloud.cholewa.commons.error.processor.ServerWebInputExceptionProcessor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.web.WebProperties;
+import org.springframework.boot.webflux.error.DefaultErrorAttributes;
+import org.springframework.context.support.StaticApplicationContext;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.codec.ServerCodecConfigurer;
+import org.springframework.web.server.MissingRequestValueException;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.server.ServerWebInputException;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GlobalErrorExceptionHandlerTest {
+
+    private GlobalErrorExceptionHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        handler = new GlobalErrorExceptionHandler(
+            new DefaultErrorAttributes(),
+            new WebProperties.Resources(),
+            new StaticApplicationContext(),
+            ServerCodecConfigurer.create()
+        );
+    }
+
+    @Test
+    void should_select_processor_by_exact_class() {
+        assertThat(handler.resolveProcessor(new ServerWebInputException("bad input")))
+            .isInstanceOf(ServerWebInputExceptionProcessor.class);
+    }
+
+    @Test
+    void should_select_supertype_processor_for_subclass() {
+        MissingRequestValueException exception =
+            new MissingRequestValueException("value", String.class, "query parameter", null);
+
+        assertThat(handler.resolveProcessor(exception))
+            .isInstanceOf(ServerWebInputExceptionProcessor.class);
+    }
+
+    @Test
+    void should_select_response_status_processor_for_response_status_exception() {
+        assertThat(handler.resolveProcessor(new ResponseStatusException(HttpStatus.NOT_FOUND)))
+            .isInstanceOf(ResponseStatusExceptionProcessor.class);
+    }
+
+    @Test
+    void should_fall_back_to_default_processor_for_unregistered_exception() {
+        assertThat(handler.resolveProcessor(new IllegalStateException("boom")))
+            .isInstanceOf(DefaultExceptionProcessor.class);
+    }
+
+    @Test
+    void should_allow_overriding_built_in_processor() {
+        ExceptionProcessor override = throwable -> Errors.builder().build();
+        handler.withCustomErrorProcessor(Map.of(ServerWebInputException.class, override));
+
+        assertThat(handler.resolveProcessor(new ServerWebInputException("bad input"))).isSameAs(override);
+    }
+
+    @Test
+    void should_prefer_most_specific_matching_processor() {
+        ExceptionProcessor subclassProcessor = throwable -> Errors.builder().build();
+        handler.withCustomErrorProcessor(Map.of(MissingRequestValueException.class, subclassProcessor));
+
+        MissingRequestValueException exception =
+            new MissingRequestValueException("value", String.class, "query parameter", null) {
+            };
+
+        assertThat(handler.resolveProcessor(exception)).isSameAs(subclassProcessor);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes processor selection in `GlobalErrorExceptionHandler`: the exact-class map lookup missed every subclass of a registered exception type (discovered in notification-service, HAS-124 — `MissingRequestValueException` fell through to the default 500 instead of a clean 400).

- **Hierarchy-aware resolution** (`resolveProcessor`): exact class first, then the most specific registered supertype, then the default processor. A processor registered on a subclass wins over one registered on a supertype. Public API unchanged.
- **`ServerWebInputExceptionProcessor` rewrite**: removes leftover debug placeholders (`"aaaa"`/`"det"`), distinguishes missing vs malformed request body by walking the cause chain for `DecodingException` (bounded depth), uses `getReason()` for messages and stops leaking exception `toString()`/method signatures into response details.
- **`WebClientResponseExceptionProcessor`**: now sets `httpStatus` (propagates the downstream status; previously `ServerResponse.status(null)` crashed rendering — newly reachable for `NotFound`/`BadRequest`/… subclasses).
- **New `ResponseStatusExceptionProcessor`**: unmatched route → 404, unsupported method → 405 etc. keep their own status instead of a generic 500.
- **`withCustomErrorProcessor`**: overriding a built-in registration no longer throws `IllegalStateException` (merge function added).
- **`DefaultExceptionProcessor`**: logs the stack trace for unhandled exceptions.
- README documents the hierarchy-aware selection.

## Consumer impact

No API break → patch release **1.0.1**. Behavior of error responses changes visibly (bug fixes): subclass exceptions now hit their supertype processor, WebClient errors propagate downstream status, framework 404/405 are no longer masked as 500. Consumers (amx, api-gateway, boiler, database, heating, shelly-cloud, water, notification-service) adopt on their next commons bump — out of scope here.

## Testing

- `GlobalErrorExceptionHandlerTest` — unit tests of selection: exact match, subclass → supertype, most-specific-wins, built-in override, ResponseStatusException tier, default fallback
- `GlobalErrorExceptionHandlerIntegrationTest` — WebFlux end-to-end: missing `@RequestParam` (HAS-124 case) → 400, missing/malformed body, path-variable type mismatch, WebClient 404 propagation, unmapped route → 404, wrong method → 405, unhandled → 500
- `mvn verify`: 16 tests, BUILD SUCCESS (Java 21, Boot 4.1.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)