### PR TITLE
HAS-131: bump README installation snippet to 1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The artifact is published to GitHub Packages:
 <dependency>
     <groupId>cloud.cholewa</groupId>
     <artifactId>cholewa-commons</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
 </dependency>
 ```
 


### PR DESCRIPTION
Updates the pinned version in the README installation snippet to the just-released 1.0.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)