### PR TITLE
HAS-132: log handled errors in every ExceptionProcessor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,8 +49,10 @@ There is no Spring auto-configuration: consumers register
 - Error responses are client-facing in **public repos' services** — keep messages free
   of internals when touching processors.
 - `logError` in the handler is intentionally suppressed; logging happens in the
-  processors instead (HAS-132): every processor logs the handled exception at `error`
-  level (class + message), but only `DefaultExceptionProcessor` logs the stack trace.
+  processors instead (HAS-132): every processor logs the handled exception
+  (`Handled [<class>]: <message>`) — `warn` for 4xx responses, `error` for 5xx
+  (processors with a dynamic status pick the level at runtime) — and only
+  `DefaultExceptionProcessor` logs the stack trace.
 
 ## Tests
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,8 +48,9 @@ There is no Spring auto-configuration: consumers register
   deliberately carry only cause messages, never stack traces or method signatures.
 - Error responses are client-facing in **public repos' services** — keep messages free
   of internals when touching processors.
-- `logError` in the handler is intentionally suppressed; the only logging for unhandled
-  exceptions is `DefaultExceptionProcessor` (message + stack trace).
+- `logError` in the handler is intentionally suppressed; logging happens in the
+  processors instead (HAS-132): every processor logs the handled exception at `error`
+  level (class + message), but only `DefaultExceptionProcessor` logs the stack trace.
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The artifact is published to GitHub Packages:
 <dependency>
     <groupId>cloud.cholewa</groupId>
     <artifactId>cholewa-commons</artifactId>
-    <version>1.0.1</version>
+    <version>1.1.0</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ Framework `ResponseStatusException`s without a more specific registration (unmat
 route → 404, unsupported method → 405, …) keep their own status; exceptions with no
 matching registration at all fall back to the default processor (HTTP 500).
 
+Every built-in processor logs the exception it handles with a uniform
+`Handled [<exception class>]: …` line — at `WARN` level for 4xx responses and `ERROR`
+for 5xx (processors with a dynamic status pick the level from the resolved status).
+Only the default processor logs the stack trace. Custom processors registered via
+`withCustomErrorProcessor` are responsible for their own logging.
+
 ### Info endpoint
 
 `InfoController` (active in web applications only) exposes `GET /info` with the

--- a/src/main/java/cloud/cholewa/commons/error/processor/ConstraintViolationExceptionProcessor.java
+++ b/src/main/java/cloud/cholewa/commons/error/processor/ConstraintViolationExceptionProcessor.java
@@ -14,7 +14,7 @@ public class ConstraintViolationExceptionProcessor implements ExceptionProcessor
 
     @Override
     public Errors apply(final Throwable throwable) {
-        log.error("Handled [{}]: {}", throwable.getClass().getSimpleName(), throwable.getMessage());
+        log.warn("Handled [{}]: {}", throwable.getClass().getSimpleName(), throwable.getMessage());
 
         return Errors.builder()
             .httpStatus(HttpStatus.BAD_REQUEST)

--- a/src/main/java/cloud/cholewa/commons/error/processor/ConstraintViolationExceptionProcessor.java
+++ b/src/main/java/cloud/cholewa/commons/error/processor/ConstraintViolationExceptionProcessor.java
@@ -4,14 +4,18 @@ import cloud.cholewa.commons.error.model.ErrorMessage;
 import cloud.cholewa.commons.error.model.Errors;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 
 import java.util.stream.Collectors;
 
+@Slf4j
 public class ConstraintViolationExceptionProcessor implements ExceptionProcessor {
 
     @Override
     public Errors apply(final Throwable throwable) {
+        log.error("Handled [{}]: {}", throwable.getClass().getSimpleName(), throwable.getMessage());
+
         return Errors.builder()
             .httpStatus(HttpStatus.BAD_REQUEST)
             .errors(

--- a/src/main/java/cloud/cholewa/commons/error/processor/DefaultExceptionProcessor.java
+++ b/src/main/java/cloud/cholewa/commons/error/processor/DefaultExceptionProcessor.java
@@ -13,7 +13,7 @@ public class DefaultExceptionProcessor implements ExceptionProcessor {
     @Override
     public Errors apply(final Throwable throwable) {
 
-        log.error("Generic exception [{}]", throwable.getClass().getSimpleName(), throwable);
+        log.error("Handled [{}]: no dedicated processor registered", throwable.getClass().getSimpleName(), throwable);
 
         return Errors.builder()
             .httpStatus(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/src/main/java/cloud/cholewa/commons/error/processor/DuplicateKeyExceptionProcessor.java
+++ b/src/main/java/cloud/cholewa/commons/error/processor/DuplicateKeyExceptionProcessor.java
@@ -12,7 +12,7 @@ public class DuplicateKeyExceptionProcessor implements ExceptionProcessor {
 
     @Override
     public Errors apply(final Throwable throwable) {
-        log.error("Handled [{}]: {}", throwable.getClass().getSimpleName(), throwable.getMessage());
+        log.warn("Handled [{}]: {}", throwable.getClass().getSimpleName(), throwable.getMessage());
 
         return Errors.builder()
             .httpStatus(HttpStatus.BAD_REQUEST)

--- a/src/main/java/cloud/cholewa/commons/error/processor/DuplicateKeyExceptionProcessor.java
+++ b/src/main/java/cloud/cholewa/commons/error/processor/DuplicateKeyExceptionProcessor.java
@@ -2,14 +2,18 @@ package cloud.cholewa.commons.error.processor;
 
 import cloud.cholewa.commons.error.model.ErrorMessage;
 import cloud.cholewa.commons.error.model.Errors;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 
 import java.util.Collections;
 
+@Slf4j
 public class DuplicateKeyExceptionProcessor implements ExceptionProcessor {
 
     @Override
     public Errors apply(final Throwable throwable) {
+        log.error("Handled [{}]: {}", throwable.getClass().getSimpleName(), throwable.getMessage());
+
         return Errors.builder()
             .httpStatus(HttpStatus.BAD_REQUEST)
             .errors(Collections.singleton(

--- a/src/main/java/cloud/cholewa/commons/error/processor/NoSuchElementProcessor.java
+++ b/src/main/java/cloud/cholewa/commons/error/processor/NoSuchElementProcessor.java
@@ -12,7 +12,7 @@ public class NoSuchElementProcessor implements ExceptionProcessor {
 
     @Override
     public Errors apply(final Throwable throwable) {
-        log.error("Handled [{}]: {}", throwable.getClass().getSimpleName(), throwable.getMessage());
+        log.warn("Handled [{}]: {}", throwable.getClass().getSimpleName(), throwable.getMessage());
 
         return Errors.builder()
             .httpStatus(HttpStatus.BAD_REQUEST)

--- a/src/main/java/cloud/cholewa/commons/error/processor/NoSuchElementProcessor.java
+++ b/src/main/java/cloud/cholewa/commons/error/processor/NoSuchElementProcessor.java
@@ -12,6 +12,7 @@ public class NoSuchElementProcessor implements ExceptionProcessor {
 
     @Override
     public Errors apply(final Throwable throwable) {
+        log.error("Handled [{}]: {}", throwable.getClass().getSimpleName(), throwable.getMessage());
 
         return Errors.builder()
             .httpStatus(HttpStatus.BAD_REQUEST)

--- a/src/main/java/cloud/cholewa/commons/error/processor/NotImplementedExceptionProcessor.java
+++ b/src/main/java/cloud/cholewa/commons/error/processor/NotImplementedExceptionProcessor.java
@@ -2,16 +2,20 @@ package cloud.cholewa.commons.error.processor;
 
 import cloud.cholewa.commons.error.model.ErrorMessage;
 import cloud.cholewa.commons.error.model.Errors;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 
 import java.util.Collections;
 
 import static cloud.cholewa.commons.error.model.UniqueError.NOT_IMPLEMENTED;
 
+@Slf4j
 public class NotImplementedExceptionProcessor implements ExceptionProcessor {
 
     @Override
     public Errors apply(final Throwable throwable) {
+        log.error("Handled [{}]: {}", throwable.getClass().getSimpleName(), throwable.getMessage());
+
         return Errors.builder()
             .httpStatus(HttpStatus.NOT_IMPLEMENTED)
             .errors(Collections.singleton(

--- a/src/main/java/cloud/cholewa/commons/error/processor/ResponseStatusExceptionProcessor.java
+++ b/src/main/java/cloud/cholewa/commons/error/processor/ResponseStatusExceptionProcessor.java
@@ -14,12 +14,16 @@ public class ResponseStatusExceptionProcessor implements ExceptionProcessor {
 
     @Override
     public Errors apply(final Throwable throwable) {
-        log.error("Handled [{}]: {}", throwable.getClass().getSimpleName(), throwable.getMessage());
-
         final ResponseStatusException exception = (ResponseStatusException) throwable;
 
         final HttpStatus httpStatus = Optional.ofNullable(HttpStatus.resolve(exception.getStatusCode().value()))
             .orElse(HttpStatus.INTERNAL_SERVER_ERROR);
+
+        if (httpStatus.is5xxServerError()) {
+            log.error("Handled [{}]: {}", throwable.getClass().getSimpleName(), throwable.getMessage());
+        } else {
+            log.warn("Handled [{}]: {}", throwable.getClass().getSimpleName(), throwable.getMessage());
+        }
 
         return Errors.builder()
             .httpStatus(httpStatus)

--- a/src/main/java/cloud/cholewa/commons/error/processor/ResponseStatusExceptionProcessor.java
+++ b/src/main/java/cloud/cholewa/commons/error/processor/ResponseStatusExceptionProcessor.java
@@ -2,16 +2,20 @@ package cloud.cholewa.commons.error.processor;
 
 import cloud.cholewa.commons.error.model.ErrorMessage;
 import cloud.cholewa.commons.error.model.Errors;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.Collections;
 import java.util.Optional;
 
+@Slf4j
 public class ResponseStatusExceptionProcessor implements ExceptionProcessor {
 
     @Override
     public Errors apply(final Throwable throwable) {
+        log.error("Handled [{}]: {}", throwable.getClass().getSimpleName(), throwable.getMessage());
+
         final ResponseStatusException exception = (ResponseStatusException) throwable;
 
         final HttpStatus httpStatus = Optional.ofNullable(HttpStatus.resolve(exception.getStatusCode().value()))

--- a/src/main/java/cloud/cholewa/commons/error/processor/ServerWebInputExceptionProcessor.java
+++ b/src/main/java/cloud/cholewa/commons/error/processor/ServerWebInputExceptionProcessor.java
@@ -2,6 +2,7 @@ package cloud.cholewa.commons.error.processor;
 
 import cloud.cholewa.commons.error.model.ErrorMessage;
 import cloud.cholewa.commons.error.model.Errors;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.codec.DecodingException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ServerWebInputException;
@@ -9,12 +10,15 @@ import org.springframework.web.server.ServerWebInputException;
 import java.util.Collections;
 import java.util.Optional;
 
+@Slf4j
 public class ServerWebInputExceptionProcessor implements ExceptionProcessor {
 
     private static final int MAX_CAUSE_DEPTH = 16;
 
     @Override
     public Errors apply(final Throwable throwable) {
+        log.error("Handled [{}]: {}", throwable.getClass().getSimpleName(), throwable.getMessage());
+
         final ServerWebInputException exception = (ServerWebInputException) throwable;
 
         return Errors.builder()

--- a/src/main/java/cloud/cholewa/commons/error/processor/ServerWebInputExceptionProcessor.java
+++ b/src/main/java/cloud/cholewa/commons/error/processor/ServerWebInputExceptionProcessor.java
@@ -17,7 +17,7 @@ public class ServerWebInputExceptionProcessor implements ExceptionProcessor {
 
     @Override
     public Errors apply(final Throwable throwable) {
-        log.error("Handled [{}]: {}", throwable.getClass().getSimpleName(), throwable.getMessage());
+        log.warn("Handled [{}]: {}", throwable.getClass().getSimpleName(), throwable.getMessage());
 
         final ServerWebInputException exception = (ServerWebInputException) throwable;
 

--- a/src/main/java/cloud/cholewa/commons/error/processor/WebClientResponseExceptionProcessor.java
+++ b/src/main/java/cloud/cholewa/commons/error/processor/WebClientResponseExceptionProcessor.java
@@ -16,17 +16,28 @@ public class WebClientResponseExceptionProcessor implements ExceptionProcessor {
     public Errors apply(final Throwable throwable) {
         final WebClientResponseException webClientResponseException = (WebClientResponseException) throwable;
 
-        log.error(
-            "Webclient got response code: {}, error: {}",
-            webClientResponseException.getStatusCode(),
-            throwable.getLocalizedMessage()
-        );
+        final HttpStatus httpStatus =
+            Optional.ofNullable(HttpStatus.resolve(webClientResponseException.getStatusCode().value()))
+                .orElse(HttpStatus.INTERNAL_SERVER_ERROR);
+
+        if (httpStatus.is5xxServerError()) {
+            log.error(
+                "Handled [{}]: downstream response {}, {}",
+                throwable.getClass().getSimpleName(),
+                webClientResponseException.getStatusCode(),
+                throwable.getLocalizedMessage()
+            );
+        } else {
+            log.warn(
+                "Handled [{}]: downstream response {}, {}",
+                throwable.getClass().getSimpleName(),
+                webClientResponseException.getStatusCode(),
+                throwable.getLocalizedMessage()
+            );
+        }
 
         return Errors.builder()
-            .httpStatus(
-                Optional.ofNullable(HttpStatus.resolve(webClientResponseException.getStatusCode().value()))
-                    .orElse(HttpStatus.INTERNAL_SERVER_ERROR)
-            )
+            .httpStatus(httpStatus)
             .errors(
                 Collections.singleton(
                     ErrorMessage.builder()

--- a/src/main/java/cloud/cholewa/commons/error/processor/WebExchangeBindExceptionProcessor.java
+++ b/src/main/java/cloud/cholewa/commons/error/processor/WebExchangeBindExceptionProcessor.java
@@ -15,6 +15,8 @@ public class WebExchangeBindExceptionProcessor implements ExceptionProcessor {
 
     @Override
     public Errors apply(final Throwable throwable) {
+        log.error("Handled [{}]: {}", throwable.getClass().getSimpleName(), throwable.getMessage());
+
         WebExchangeBindException exception = (WebExchangeBindException) throwable;
 
         return Errors.builder()

--- a/src/main/java/cloud/cholewa/commons/error/processor/WebExchangeBindExceptionProcessor.java
+++ b/src/main/java/cloud/cholewa/commons/error/processor/WebExchangeBindExceptionProcessor.java
@@ -5,6 +5,7 @@ import cloud.cholewa.commons.error.model.Errors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpStatus;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.support.WebExchangeBindException;
 
 import java.util.Optional;
@@ -15,9 +16,14 @@ public class WebExchangeBindExceptionProcessor implements ExceptionProcessor {
 
     @Override
     public Errors apply(final Throwable throwable) {
-        log.error("Handled [{}]: {}", throwable.getClass().getSimpleName(), throwable.getMessage());
-
         WebExchangeBindException exception = (WebExchangeBindException) throwable;
+
+        log.warn(
+            "Handled [{}]: {} validation error(s), fields: {}",
+            throwable.getClass().getSimpleName(),
+            exception.getErrorCount(),
+            exception.getFieldErrors().stream().map(FieldError::getField).collect(Collectors.toSet())
+        );
 
         return Errors.builder()
             .httpStatus(HttpStatus.BAD_REQUEST)


### PR DESCRIPTION
## Summary
- Add a uniform `Handled [<class>]: ...` log line to every `ExceptionProcessor`: `warn` for 4xx responses, `error` for 5xx (processors with a dynamic status — `ResponseStatusExceptionProcessor`, `WebClientResponseExceptionProcessor` — pick the level at runtime).
- `WebExchangeBindExceptionProcessor` logs error count + rejected field names instead of the verbose multi-line `getMessage()`.
- Stack trace logging stays only in `DefaultExceptionProcessor`.
- HTTP response bodies (`Errors` contract) are unchanged — logging only.
- Updated the `CLAUDE.md` error-handling notes.

## ⚠️ Log contract changes (release-note this in 1.1.0)
Out-of-band changes that may affect consumer log parsing/alerting:
- **Level downgrade ERROR → WARN** for all 4xx handled errors, including downstream 4xx from `WebClientResponseExceptionProcessor` (401/403/404/429 from called services). Alerts filtering on ERROR will no longer fire for these — repoint them at WARN or at the 5xx lines.
- **Renamed literals**: `Generic exception [X]` → `Handled [X]: no dedicated processor registered` (`DefaultExceptionProcessor`), `Webclient got response code: ...` → `Handled [X]: downstream response <status>, <message>`.
- Workspace-wide grep confirms no org repo (incl. `deployment-tools`) keys on the old literals; external consumers of this library must check their own alerting.

## Test plan
- `mvn verify` green (16 tests, incl. `GlobalErrorExceptionHandlerIntegrationTest`); `WARN`/`ERROR` split visible in test console output.

Jira: [HAS-132](https://magikabdul.atlassian.net/browse/HAS-132)

🤖 Generated with [Claude Code](https://claude.com/claude-code)