### PR TITLE
HAS-137: render database integrity violations as 400 instead of 500

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,16 @@ There is no Spring auto-configuration: consumers register
 - Built-in registrations include a `ResponseStatusException` tier — unmatched routes
   (404), unsupported methods (405) etc. keep their own status instead of becoming 500 —
   and `WebClientResponseExceptionProcessor` propagates the downstream HTTP status.
+- **Database integrity tier** (HAS-137): `org.springframework.dao.DuplicateKeyException`
+  → 400 `Duplicate Key`, the parent `DataIntegrityViolationException` → 400
+  `Data integrity violation`; hierarchy-aware selection keeps duplicates on the more
+  specific processor. Neither sets `details` — raw driver text names tables, columns and
+  constraints, so it stays in the log only.
+- `spring-tx` is a **compile-scope** dependency and must stay one: the handler holds class
+  literals for the `org.springframework.dao` types, so a `provided` scope (not transitive)
+  would break every consumer without its own spring-tx — `ai-service` has none, and would
+  fail at startup with `NoClassDefFoundError`. In Boot 4 this pulls no autoconfiguration:
+  `TransactionAutoConfiguration` lives in the separate `spring-boot-transaction` module.
 - `ServerWebInputExceptionProcessor` distinguishes missing vs malformed request body by
   walking the cause chain for `DecodingException` (bounded depth); response `details`
   deliberately carry only cause messages, never stack traces or method signatures.

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ GitHub Packages requires authentication even for public artifacts — configure 
 
 Register `GlobalErrorExceptionHandler` as a bean; it renders every unhandled exception
 as an `Errors` JSON body. Processors for common exceptions (validation, `WebClient`
-errors, `NoSuchElementException`, …) are built in; service-specific exceptions plug in
-via `withCustomErrorProcessor`:
+errors, `NoSuchElementException`, database integrity violations, …) are built in;
+service-specific exceptions plug in via `withCustomErrorProcessor`:
 
 ```java
 @Bean
@@ -85,6 +85,13 @@ for its exact class or, failing that, for its most specific registered supertype
 Framework `ResponseStatusException`s without a more specific registration (unmatched
 route → 404, unsupported method → 405, …) keep their own status; exceptions with no
 matching registration at all fall back to the default processor (HTTP 500).
+
+Database integrity errors have their own tier: `DuplicateKeyException` renders as
+`400` with the message `Duplicate Key`, and every other
+`DataIntegrityViolationException` (a `NOT NULL` or check-constraint violation, …) as
+`400` with `Data integrity violation`. Both deliberately omit `details` — the raw
+driver text names tables, columns and constraints, which must not reach a client; it
+is logged instead. These processors are why the library depends on `spring-tx`.
 
 Every built-in processor logs the exception it handles with a uniform
 `Handled [<exception class>]: …` line — at `WARN` level for 4xx responses and `ERROR`

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
-
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-tx</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>

--- a/src/main/java/cloud/cholewa/commons/error/GlobalErrorExceptionHandler.java
+++ b/src/main/java/cloud/cholewa/commons/error/GlobalErrorExceptionHandler.java
@@ -3,6 +3,7 @@ package cloud.cholewa.commons.error;
 import cloud.cholewa.commons.error.model.Errors;
 import cloud.cholewa.commons.error.model.NotImplementedException;
 import cloud.cholewa.commons.error.processor.ConstraintViolationExceptionProcessor;
+import cloud.cholewa.commons.error.processor.DataIntegrityViolationExceptionProcessor;
 import cloud.cholewa.commons.error.processor.DefaultExceptionProcessor;
 import cloud.cholewa.commons.error.processor.DuplicateKeyExceptionProcessor;
 import cloud.cholewa.commons.error.processor.ExceptionProcessor;
@@ -21,6 +22,8 @@ import org.springframework.boot.webflux.autoconfigure.error.AbstractErrorWebExce
 import org.springframework.boot.webflux.error.ErrorAttributes;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.annotation.Order;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.http.codec.ServerCodecConfigurer;
 import org.springframework.web.bind.support.WebExchangeBindException;
 import org.springframework.web.reactive.function.BodyInserters;
@@ -32,7 +35,6 @@ import org.springframework.web.reactive.function.server.ServerRequest;
 import org.springframework.web.reactive.function.server.ServerResponse;
 import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.server.ServerWebInputException;
-import org.yaml.snakeyaml.constructor.DuplicateKeyException;
 import reactor.core.publisher.Mono;
 
 import java.util.Map;
@@ -60,6 +62,7 @@ public class GlobalErrorExceptionHandler extends AbstractErrorWebExceptionHandle
         processors = Map.ofEntries(
             Map.entry(ConstraintViolationException.class, new ConstraintViolationExceptionProcessor()),
             Map.entry(DuplicateKeyException.class, new DuplicateKeyExceptionProcessor()),
+            Map.entry(DataIntegrityViolationException.class, new DataIntegrityViolationExceptionProcessor()),
             Map.entry(NotImplementedException.class, new NotImplementedExceptionProcessor()),
             Map.entry(ResponseStatusException.class, new ResponseStatusExceptionProcessor()),
             Map.entry(ServerWebInputException.class, new ServerWebInputExceptionProcessor()),

--- a/src/main/java/cloud/cholewa/commons/error/processor/DataIntegrityViolationExceptionProcessor.java
+++ b/src/main/java/cloud/cholewa/commons/error/processor/DataIntegrityViolationExceptionProcessor.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 import java.util.Collections;
 
 @Slf4j
-public class DuplicateKeyExceptionProcessor implements ExceptionProcessor {
+public class DataIntegrityViolationExceptionProcessor implements ExceptionProcessor {
 
     @Override
     public Errors apply(final Throwable throwable) {
@@ -18,7 +18,7 @@ public class DuplicateKeyExceptionProcessor implements ExceptionProcessor {
             .httpStatus(HttpStatus.BAD_REQUEST)
             .errors(Collections.singleton(
                 ErrorMessage.builder()
-                    .message("Duplicate Key")
+                    .message("Data integrity violation")
                     .build()
             ))
             .build();

--- a/src/test/java/cloud/cholewa/commons/error/GlobalErrorExceptionHandlerIntegrationTest.java
+++ b/src/test/java/cloud/cholewa/commons/error/GlobalErrorExceptionHandlerIntegrationTest.java
@@ -9,6 +9,8 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.codec.ServerCodecConfigurer;
@@ -63,6 +65,16 @@ class GlobalErrorExceptionHandlerIntegrationTest {
         @GetMapping("/downstream")
         String downstream() {
             throw WebClientResponseException.create(404, "Not Found", HttpHeaders.EMPTY, new byte[0], null);
+        }
+
+        @GetMapping("/duplicate-key")
+        String duplicateKey() {
+            throw new DuplicateKeyException("boom");
+        }
+
+        @GetMapping("/null-value")
+        String nullValue() {
+            throw new DataIntegrityViolationException("null value in column");
         }
     }
 
@@ -159,5 +171,25 @@ class GlobalErrorExceptionHandlerIntegrationTest {
         webTestClient.get().uri("/unhandled")
             .exchange()
             .expectStatus().is5xxServerError();
+    }
+
+    @Test
+    void should_return_bad_request_error_without_details_for_data_integrity_violation() {
+        webTestClient.get().uri("/null-value")
+            .exchange()
+            .expectStatus().isBadRequest()
+            .expectBody()
+            .jsonPath("$.errors[0].message").isEqualTo("Data integrity violation")
+            .jsonPath("$.errors[0].details").doesNotExist();
+    }
+
+    @Test
+    void should_return_bad_request_error_without_details_for_duplicate_key_exception() {
+        webTestClient.get().uri("/duplicate-key")
+            .exchange()
+            .expectStatus().isBadRequest()
+            .expectBody()
+            .jsonPath("$.errors[0].message").isEqualTo("Duplicate Key")
+            .jsonPath("$.errors[0].details").doesNotExist();
     }
 }

--- a/src/test/java/cloud/cholewa/commons/error/GlobalErrorExceptionHandlerTest.java
+++ b/src/test/java/cloud/cholewa/commons/error/GlobalErrorExceptionHandlerTest.java
@@ -1,7 +1,9 @@
 package cloud.cholewa.commons.error;
 
 import cloud.cholewa.commons.error.model.Errors;
+import cloud.cholewa.commons.error.processor.DataIntegrityViolationExceptionProcessor;
 import cloud.cholewa.commons.error.processor.DefaultExceptionProcessor;
+import cloud.cholewa.commons.error.processor.DuplicateKeyExceptionProcessor;
 import cloud.cholewa.commons.error.processor.ExceptionProcessor;
 import cloud.cholewa.commons.error.processor.ResponseStatusExceptionProcessor;
 import cloud.cholewa.commons.error.processor.ServerWebInputExceptionProcessor;
@@ -10,6 +12,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.web.WebProperties;
 import org.springframework.boot.webflux.error.DefaultErrorAttributes;
 import org.springframework.context.support.StaticApplicationContext;
+import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.codec.ServerCodecConfigurer;
 import org.springframework.web.server.MissingRequestValueException;
@@ -79,5 +84,23 @@ class GlobalErrorExceptionHandlerTest {
             };
 
         assertThat(handler.resolveProcessor(exception)).isSameAs(subclassProcessor);
+    }
+
+    @Test
+    void should_select_duplicate_key_processor_for_spring_duplicate_key_exception() {
+        assertThat(handler.resolveProcessor(new DuplicateKeyException("boom")))
+            .isInstanceOf(DuplicateKeyExceptionProcessor.class);
+    }
+
+    @Test
+    void should_select_integrity_processor_for_other_data_integrity_violations() {
+        assertThat(handler.resolveProcessor(new DataIntegrityViolationException("null value in column")))
+            .isInstanceOf(DataIntegrityViolationExceptionProcessor.class);
+    }
+
+    @Test
+    void should_fall_back_to_default_processor_for_infrastructure_data_access_errors() {
+        assertThat(handler.resolveProcessor(new DataAccessResourceFailureException("db down")))
+            .isInstanceOf(DefaultExceptionProcessor.class);
     }
 }


### PR DESCRIPTION
Found by the `service-review` during HAS-126 (database-service migration).

## The bug

`GlobalErrorExceptionHandler` registered `org.yaml.snakeyaml.constructor.DuplicateKeyException`
— a YAML parsing error — instead of Spring's. `DuplicateKeyExceptionProcessor` was therefore dead
code and every real uniqueness violation fell through to `DefaultExceptionProcessor` as a **500**.
`database-service` is the only consumer with a database and the one that hits it.

## Changes

- **`spring-tx` added in compile scope.** `org.springframework.dao` was not on the library's
  classpath at all, so the correct exception was not even importable. The scope is deliberate:
  `provided` is not transitive and `ai-service` has no `spring-tx` of its own, so the class literal
  in the handler constructor would fail its startup with `NoClassDefFoundError`. In Boot 4 this
  pulls **no** autoconfiguration — `TransactionAutoConfiguration` lives in the separate
  `spring-boot-transaction` module. 286 KB, only `spring-beans` behind it.
- **Registrations:** `org.springframework.dao.DuplicateKeyException` → 400 `Duplicate Key`, plus its
  parent `DataIntegrityViolationException` → 400 `Data integrity violation`, which also covers the
  `NOT NULL` and check-constraint violations that render as 500 today. Hierarchy-aware selection
  (HAS-131) keeps duplicates on the more specific processor.
- **Boundary kept at 400/500:** `DataAccessException` is *not* registered, so infrastructure
  failures (`DataAccessResourceFailureException`, query timeouts, bad SQL grammar) still return 500
  — they are not the client's fault. A test pins this.
- **No more database internals in responses:** both processors dropped
  `.details(throwable.getMessage())`; PostgreSQL text names tables, columns and constraints. The raw
  message is still logged (`log.warn`, the HAS-132 convention).
- README and `CLAUDE.md` document the new tier and why the `spring-tx` scope must stay `compile`.

## Verification

`mvn verify` on JDK 21: 21/21 tests, enforcer (`dependencyConvergence`) and `tidy:check` green.
`dependency:tree` confirms `org.springframework:spring-tx:jar:7.0.8:compile`.

The R2DBC assumption behind HAS-138 was checked in `spring-r2dbc` bytecode:
`ConnectionFactoryUtils.convertR2dbcException` maps SQL states 23505/23000 to `DuplicateKeyException`
and the rest of class 23 to `DataIntegrityViolationException` — so a unique index really does produce
`Duplicate Key`, and a `NOT NULL` violation `Data integrity violation`.

## Release

Next version is **1.2.0**, not a patch: this adds a public class and changes the response body.
Consumers on 1.1.0 are `ai-service`, `database-service` and `notification-service`; only
`database-service` needs the bump, as part of HAS-138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)