### PR TITLE
HAS-137: bump the README installation snippet to 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The artifact is published to GitHub Packages:
 <dependency>
     <groupId>cloud.cholewa</groupId>
     <artifactId>cholewa-commons</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
 </dependency>
 ```
 


### PR DESCRIPTION
One line: the installation snippet still pinned 1.1.0 after the 1.2.0 release.

Noted for next time — this bump belongs in the feature PR itself. The version to be released
is already decided when the PR is written, so splitting it into a follow-up PR is pure overhead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)