### PR TITLE
HAS-146: extract the shared R2DBC connection configuration into cholewa-commons

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,10 +7,12 @@ consumers, not just the org ones. Published to GitHub Packages
 (`maven.pkg.github.com/magikabdul/cholewa-commons`, pom server id `github-prv`).
 Java 21, Spring Boot 4.1.0 (`spring-boot-starter-parent`), Maven.
 
-Org consumers: `amx-service`, `api-gateway-service`, `boiler-service`,
-`database-service`, `heating-service`, `shelly-cloud-service`, `water-service` — all
-still on 0.2.x until their own Java 21 migrations; 1.0.x is a breaking line
-(Java 21 bytecode, Jackson 3).
+Org consumers, with the version each is on today (2026-08-13): `boiler-service`,
+`database-service`, `heating-service` and `water-service` on **1.2.0**; `ai-service` and
+`notification-service` on **1.1.0**; `amx-service` and `shelly-cloud-service` on 0.2.1 and
+`api-gateway-service` on 0.1.2 — those three stay on the old line until their own Java 21
+migrations, because 1.0.x is a breaking one (Java 21 bytecode, Jackson 3). This list drifts:
+the authoritative answer is the `cholewa-commons.version` property in each consumer's pom.
 
 Org-wide conventions and working rules (PR flow, branch naming `feature/HAS-<n>`,
 "user writes library code, Claude reviews", public-repo hygiene) live in the workspace
@@ -26,12 +28,18 @@ Common building blocks for **reactive (WebFlux)** Spring Boot services:
   exception as an `Errors` JSON body via a pluggable `ExceptionProcessor` mechanism.
 - `error/model/` — the JSON error contract shared by all services: `Errors`,
   `ErrorMessage`, `UniqueError`, `ErrorId`, plus `NotImplementedException`.
+- `database/` — `R2dbcConnectionFactoryAutoConfiguration` and `DatabaseProperties`: a
+  pooled PostgreSQL `ConnectionFactory` built from the `database.*` property group, so a
+  database-backed service carries no `DbConfig` of its own (HAS-146).
 - `info/` — `InfoController`: `GET /info` with app name, version and git commit
   (requires `application.title`/`application.version` properties and `GitProperties`
   in the consumer).
 
-There is no Spring auto-configuration: consumers register
-`GlobalErrorExceptionHandler` as a bean themselves (see README for the snippet).
+The only auto-configuration is `R2dbcConnectionFactoryAutoConfiguration` (registered in
+`META-INF/spring/…AutoConfiguration.imports`, guarded by `@ConditionalOnClass` on the R2DBC
+types and `@ConditionalOnProperty` on `database.host`). Everything else is opt-in:
+consumers register `GlobalErrorExceptionHandler` as a bean themselves (see README for the
+snippet).
 
 ## Error handling — the parts worth knowing before changing anything
 
@@ -64,7 +72,41 @@ There is no Spring auto-configuration: consumers register
   (processors with a dynamic status pick the level at runtime) — and only
   `DefaultExceptionProcessor` logs the stack trace.
 
+## R2DBC connection factory — what the guards are for
+
+- Ordered `@AutoConfiguration(before = R2dbcAutoConfiguration.class)`: Boot's own factory is
+  `@ConditionalOnMissingBean` as well, so without the explicit ordering the winner is
+  undefined.
+- Two guards keep the library inert for consumers that do not want it.
+  `@ConditionalOnClass({ConnectionFactory.class, ConnectionPool.class})` names **both** types
+  — `r2dbc-pool` does not come with `spring-boot-r2dbc`; in the services it arrives through
+  `spring-boot-data-r2dbc`, so a consumer can have the SPI without the pool. And
+  `@ConditionalOnProperty(prefix = "database", name = "host")` keeps it off for anyone
+  configuring the database the Boot way, through `spring.r2dbc.*` — without it, upgrading to
+  1.3.0 would break such a consumer's startup on a `ConnectionFactoryOptions` null.
+- The r2dbc dependencies are `provided` — safe here, unlike `spring-tx` above, exactly
+  because `@ConditionalOnClass` is read via ASM and the class never loads without them.
+- `@EnableR2dbcRepositories` must **not** move into this package: with no `basePackages` the
+  scan base is the annotated class's package, so no consumer repository would be found, and
+  its mere presence makes `R2dbcRepositoriesAutoConfiguration` back off. It stays in the
+  service.
+- The nested `Pool` record needs a bare `@DefaultValue` on the `pool` component itself, not
+  only on its fields — otherwise a missing `database.pool` group binds to `null` and the pool
+  build NPEs.
+- Pool size stays per-service configuration: the managed database allows 22 backend
+  connections in total (heating 8 / database 6 / water 4), and a re-split must not require a
+  library release. Note that the `r2dbc_pool_*` metrics are tagged with the **Spring bean
+  name** (`connectionFactory`) by `ConnectionPoolMetricsAutoConfiguration`, not with
+  `ConnectionPoolConfiguration.name(...)`, which only feeds the JMX object name.
+
 ## Tests
+
+`R2dbcConnectionFactoryAutoConfigurationTest` drives the auto-configuration with
+`ApplicationContextRunner`: every guard above, the pool defaults and overrides (asserted on
+the built pool via `getMetrics().getMaxAllocatedSize()`, not just on the bound properties),
+and — through `ImportCandidates` — that the class is really listed in the `.imports` file.
+Run it with `clean`: `mvn test` alone keeps a stale copy of that resource in `target/classes`
+and the check passes even when the file is gone.
 
 `GlobalErrorExceptionHandlerTest` covers selection logic (exact / subclass /
 most-specific / override / fallback); `GlobalErrorExceptionHandlerIntegrationTest` is a
@@ -82,4 +124,8 @@ a major Spring bump may legitimately break them; update the expected text, not t
   `versions:set` from the tag and deploys to GitHub Packages. Tags have no `v` prefix.
 - CI/CD: `CI.yml` (build + tests), `sonar.yml` (SonarCloud), `package.yml` (publish on
   GitHub release). Release flow: the `release` skill from the `smart-home` plugin.
-- After a release, bump the pinned version in the README installation snippet.
+- The README installation snippet pins the version **being released** and is bumped in the
+  same PR as the change, not in a follow-up commit after the release — `main` should always
+  advertise the version a consumer is meant to depend on. The trade-off is accepted: between
+  the merge and `gh release create` the README names a version that is not on GitHub Packages
+  yet, so do not let a merged release PR sit unreleased.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,12 @@ snippet).
   1.3.0 would break such a consumer's startup on a `ConnectionFactoryOptions` null.
 - The r2dbc dependencies are `provided` — safe here, unlike `spring-tx` above, exactly
   because `@ConditionalOnClass` is read via ASM and the class never loads without them.
+- The five connection properties carry bean-validation constraints and the record is
+  `@Validated`: `ConnectionFactoryOptions` rejects a null with a message that does not name
+  the property, so a half-configured consumer would otherwise see only `value must not be
+  null`. `sslMode` is a property (`database.ssl-mode`, default `REQUIRE`) rather than a
+  constant, so a consumer on a database without TLS is not forced to declare its own
+  `ConnectionFactory` bean just to change one option.
 - `@EnableR2dbcRepositories` must **not** move into this package: with no `basePackages` the
   scan base is the annotated class's package, so no consumer repository would be found, and
   its mere presence makes `R2dbcRepositoriesAutoConfiguration` back off. It stays in the

--- a/README.md
+++ b/README.md
@@ -129,11 +129,20 @@ database:
 | `database.port` | — | Port |
 | `database.name` | — | Database name |
 | `database.username` | — | User |
-| `database.password` | — | Password |
-| `database.pool.initial-size` | `2` | Connections opened when the pool warms up |
-| `database.pool.max-size` | `4` | Maximum connections — set per service; the database has a global limit |
+| `database.password` | — | Password (may be empty, but must be present) |
+| `database.ssl-mode` | `REQUIRE` | Driver `sslMode`; lower it only for a database without TLS |
+| `database.pool.initial-size` | `2` | Connections opened when the pool warms up — must not exceed `max-size` |
+| `database.pool.max-size` | `4` | Maximum connections; see the warning below |
 | `database.pool.max-acquire-time` | `PT10S` | How long a caller waits for a free connection |
 | `database.pool.max-idle-time` | `PT5M` | Idle connection lifetime |
+
+The five connection properties are mandatory and validated at bind time, so a missing one
+fails the startup with a message naming it rather than a bare `value must not be null`.
+
+> **Replacing an existing `DbConfig`?** Set `database.pool.max-size` explicitly in the same
+> change. The default of `4` is sized for a new service, and a service whose own pool was
+> larger silently shrinks to it — under load the callers then time out on
+> `max-acquire-time` instead of queueing on the connections they used to have.
 
 Repositories are deliberately **not** enabled here — keep `@EnableR2dbcRepositories` on a
 class in the service (or rely on Boot's own auto-configuration), so the scan starts from the

--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@
 ![GitHub commit activity](https://img.shields.io/github/commit-activity/m/magikabdul/cholewa-commons?style=plastic)
 
 Common building blocks for reactive (WebFlux) Spring Boot services: a global error
-handler with a pluggable exception-processor mechanism, a consistent JSON error model
-and a simple `/info` endpoint exposing application name, version and git commit.
+handler with a pluggable exception-processor mechanism, a consistent JSON error model,
+an auto-configured pooled R2DBC connection factory and a simple `/info` endpoint exposing
+application name, version and git commit.
 
 Used by the [smart-home-automation-system](https://github.com/smart-home-automation-system)
 services (`amx-service`, `api-gateway-service`, `boiler-service`, `database-service`,
@@ -98,6 +99,48 @@ Every built-in processor logs the exception it handles with a uniform
 for 5xx (processors with a dynamic status pick the level from the resolved status).
 Only the default processor logs the stack trace. Custom processors registered via
 `withCustomErrorProcessor` are responsible for their own logging.
+
+### R2DBC connection factory
+
+Services persisting to PostgreSQL over R2DBC get a pooled `ConnectionFactory` from
+auto-configuration — no `DbConfig` class of their own. It activates when
+`io.r2dbc.spi.ConnectionFactory` and `io.r2dbc.pool.ConnectionPool` are on the classpath
+(both arrive with `spring-boot-starter-data-r2dbc`) and `database.host` is set, and it backs
+off when the service declares a `ConnectionFactory` bean itself. Services configuring their
+database the Boot way, through `spring.r2dbc.*`, are unaffected.
+
+The connection uses `sslMode=REQUIRE` and is wrapped in an `io.r2dbc.pool.ConnectionPool`
+disposed on shutdown:
+
+```yaml
+database:
+  host: ${database-host:localhost}
+  port: ${database-port:5432}
+  name: ${database-name:dummyName}
+  username: ${database-user:dummyUser}
+  password: ${database-password:dummyPassword}
+  pool:
+    max-size: 8
+```
+
+| Property | Default | Description |
+|---|---|---|
+| `database.host` | — | Host; **also the switch** that activates the auto-configuration |
+| `database.port` | — | Port |
+| `database.name` | — | Database name |
+| `database.username` | — | User |
+| `database.password` | — | Password |
+| `database.pool.initial-size` | `2` | Connections opened when the pool warms up |
+| `database.pool.max-size` | `4` | Maximum connections — set per service; the database has a global limit |
+| `database.pool.max-acquire-time` | `PT10S` | How long a caller waits for a free connection |
+| `database.pool.max-idle-time` | `PT5M` | Idle connection lifetime |
+
+Repositories are deliberately **not** enabled here — keep `@EnableR2dbcRepositories` on a
+class in the service (or rely on Boot's own auto-configuration), so the scan starts from the
+service's package and not from this library's.
+
+The bean is named `connectionFactory`, which is also the `name` tag of the `r2dbc_pool_*`
+metrics when Actuator and a Micrometer registry are on the classpath.
 
 ### Info endpoint
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The artifact is published to GitHub Packages:
 <dependency>
     <groupId>cloud.cholewa</groupId>
     <artifactId>cholewa-commons</artifactId>
-    <version>1.2.0</version>
+    <version>1.3.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,12 @@
 		<sonar.projectKey>magikabdul_cholewa-commons</sonar.projectKey>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 
+		<!-- surefire appends the Mockito agent to this; sonar.yml overwrites it from the command
+             line with jacoco's prepare-agent, so it must exist for the @{argLine} late replacement -->
+		<argLine/>
+
 		<!--  plugins versions-->
+		<maven-dependency-plugin.version>3.10.0</maven-dependency-plugin.version>
 		<maven-enforcer-plugin.version>3.6.3</maven-enforcer-plugin.version>
 		<maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
 		<tidy-maven-plugin.version>1.4.0</tidy-maven-plugin.version>
@@ -97,9 +102,24 @@
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<version>${maven-dependency-plugin.version}</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>properties</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>${maven-surefire-plugin.version}</version>
 				<configuration>
+					<!-- loading the mock maker as a real agent: self-attaching stops working on newer
+                         JDKs and already warns. The path property comes from dependency:properties -->
+					<argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
 					<includes>
 						<include>**/*Test.java</include>
 						<include>**/*IT.java</include>

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,21 @@
 			<artifactId>spring-tx</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-r2dbc</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.r2dbc</groupId>
+			<artifactId>r2dbc-spi</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.r2dbc</groupId>
+			<artifactId>r2dbc-pool</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
 			<optional>true</optional>
@@ -71,6 +86,12 @@
 			<artifactId>spring-boot-starter-webflux-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>r2dbc-postgresql</artifactId>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,6 @@
 			<artifactId>r2dbc-postgresql</artifactId>
 			<scope>test</scope>
 		</dependency>
-
 	</dependencies>
 
 	<build>

--- a/src/main/java/cloud/cholewa/commons/database/DatabaseProperties.java
+++ b/src/main/java/cloud/cholewa/commons/database/DatabaseProperties.java
@@ -18,8 +18,8 @@ public record DatabaseProperties(
     public record Pool(
         @DefaultValue("2") int initialSize,
         @DefaultValue("4") int maxSize,
-        @DefaultValue("PT10s") Duration maxAcquireTime,
-        @DefaultValue("PT5m") Duration maxIdleTime
+        @DefaultValue("PT10S") Duration maxAcquireTime,
+        @DefaultValue("PT5M") Duration maxIdleTime
     ) {
     }
 }

--- a/src/main/java/cloud/cholewa/commons/database/DatabaseProperties.java
+++ b/src/main/java/cloud/cholewa/commons/database/DatabaseProperties.java
@@ -1,17 +1,25 @@
 package cloud.cholewa.commons.database;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.bind.DefaultValue;
+import org.springframework.validation.annotation.Validated;
 
 import java.time.Duration;
 
+//the connection details are all mandatory - ConnectionFactoryOptions rejects a null value with
+//a message that does not name the property, so they are validated at bind time instead
+@Validated
 @ConfigurationProperties("database")
 public record DatabaseProperties(
-    String host,
-    Integer port,
-    String name,
-    String username,
-    String password,
+    @NotBlank String host,
+    @NotNull Integer port,
+    @NotBlank String name,
+    @NotBlank String username,
+    //an empty password is a legitimate setup, a missing one is not
+    @NotNull String password,
+    @DefaultValue("REQUIRE") String sslMode,
     @DefaultValue Pool pool
 ) {
 

--- a/src/main/java/cloud/cholewa/commons/database/DatabaseProperties.java
+++ b/src/main/java/cloud/cholewa/commons/database/DatabaseProperties.java
@@ -1,0 +1,25 @@
+package cloud.cholewa.commons.database;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+
+import java.time.Duration;
+
+@ConfigurationProperties("database")
+public record DatabaseProperties(
+    String host,
+    Integer port,
+    String name,
+    String username,
+    String password,
+    @DefaultValue Pool pool
+) {
+
+    public record Pool(
+        @DefaultValue("2") int initialSize,
+        @DefaultValue("4") int maxSize,
+        @DefaultValue("PT10s") Duration maxAcquireTime,
+        @DefaultValue("PT5m") Duration maxIdleTime
+    ) {
+    }
+}

--- a/src/main/java/cloud/cholewa/commons/database/R2dbcConnectionFactoryAutoConfiguration.java
+++ b/src/main/java/cloud/cholewa/commons/database/R2dbcConnectionFactoryAutoConfiguration.java
@@ -1,0 +1,54 @@
+package cloud.cholewa.commons.database;
+
+import io.r2dbc.pool.ConnectionPool;
+import io.r2dbc.pool.ConnectionPoolConfiguration;
+import io.r2dbc.spi.ConnectionFactories;
+import io.r2dbc.spi.ConnectionFactory;
+import io.r2dbc.spi.ConnectionFactoryOptions;
+import io.r2dbc.spi.Option;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.r2dbc.autoconfigure.R2dbcAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@AutoConfiguration(before = R2dbcAutoConfiguration.class)
+@ConditionalOnClass(ConnectionFactory.class)
+@EnableConfigurationProperties(DatabaseProperties.class)
+public class R2dbcConnectionFactoryAutoConfiguration {
+
+
+    //destroyMethod is explicit: the inferred close() returns a cold Publisher nobody subscribes to,
+    //so the pooled connections would survive every shutdown
+    @Bean(destroyMethod = "dispose")
+    @ConditionalOnMissingBean(ConnectionFactory.class)
+    ConnectionFactory connectionFactory(
+        DatabaseProperties databaseProperties,
+        @Value("${spring.application.name:r2dbc}") String poolName
+    ) {
+        ConnectionFactory connectionFactory = ConnectionFactories.get(ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "postgresql")
+            .option(ConnectionFactoryOptions.HOST, databaseProperties.host())
+            .option(ConnectionFactoryOptions.PORT, databaseProperties.port())
+            .option(ConnectionFactoryOptions.DATABASE, databaseProperties.name())
+            .option(ConnectionFactoryOptions.USER, databaseProperties.username())
+            .option(ConnectionFactoryOptions.PASSWORD, databaseProperties.password())
+            .option(Option.valueOf("sslMode"), "REQUIRE")
+            .build()
+        );
+
+        //R2dbcAutoConfiguration backs off once this bean exists, so without the pool every query -
+        //and every /actuator/health call, which the health indicator answers with its own connection -
+        //opens a physical connection to a managed database that allows 22 of them in total
+        return new ConnectionPool(ConnectionPoolConfiguration.builder(connectionFactory)
+            .name(poolName)
+            .initialSize(databaseProperties.pool().initialSize())
+            .maxSize(databaseProperties.pool().maxSize())
+            .maxAcquireTime(databaseProperties.pool().maxAcquireTime())
+            .maxIdleTime(databaseProperties.pool().maxIdleTime())
+            .build()
+        );
+    }
+}

--- a/src/main/java/cloud/cholewa/commons/database/R2dbcConnectionFactoryAutoConfiguration.java
+++ b/src/main/java/cloud/cholewa/commons/database/R2dbcConnectionFactoryAutoConfiguration.java
@@ -10,23 +10,27 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.r2dbc.autoconfigure.R2dbcAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 
+//ConnectionPool is guarded as well: it does not come with spring-boot-r2dbc, so a consumer may have
+//the SPI without the pool. The property guard keeps the auto-configuration inert for consumers that
+//configure their database the Boot way, through spring.r2dbc.*
 @AutoConfiguration(before = R2dbcAutoConfiguration.class)
-@ConditionalOnClass(ConnectionFactory.class)
+@ConditionalOnClass({ConnectionFactory.class, ConnectionPool.class})
+@ConditionalOnProperty(prefix = "database", name = "host")
 @EnableConfigurationProperties(DatabaseProperties.class)
 public class R2dbcConnectionFactoryAutoConfiguration {
-
 
     //destroyMethod is explicit: the inferred close() returns a cold Publisher nobody subscribes to,
     //so the pooled connections would survive every shutdown
     @Bean(destroyMethod = "dispose")
-    @ConditionalOnMissingBean(ConnectionFactory.class)
+    @ConditionalOnMissingBean
     ConnectionFactory connectionFactory(
-        DatabaseProperties databaseProperties,
-        @Value("${spring.application.name:r2dbc}") String poolName
+        final DatabaseProperties databaseProperties,
+        @Value("${spring.application.name:r2dbc}") final String poolName
     ) {
         ConnectionFactory connectionFactory = ConnectionFactories.get(ConnectionFactoryOptions.builder()
             .option(ConnectionFactoryOptions.DRIVER, "postgresql")
@@ -41,13 +45,16 @@ public class R2dbcConnectionFactoryAutoConfiguration {
 
         //R2dbcAutoConfiguration backs off once this bean exists, so without the pool every query -
         //and every /actuator/health call, which the health indicator answers with its own connection -
-        //opens a physical connection to a managed database that allows 22 of them in total
+        //opens its own physical connection. The pool name is the service name, so the r2dbc_pool_*
+        //metrics tell the services apart
+        final DatabaseProperties.Pool pool = databaseProperties.pool();
+
         return new ConnectionPool(ConnectionPoolConfiguration.builder(connectionFactory)
             .name(poolName)
-            .initialSize(databaseProperties.pool().initialSize())
-            .maxSize(databaseProperties.pool().maxSize())
-            .maxAcquireTime(databaseProperties.pool().maxAcquireTime())
-            .maxIdleTime(databaseProperties.pool().maxIdleTime())
+            .initialSize(pool.initialSize())
+            .maxSize(pool.maxSize())
+            .maxAcquireTime(pool.maxAcquireTime())
+            .maxIdleTime(pool.maxIdleTime())
             .build()
         );
     }

--- a/src/main/java/cloud/cholewa/commons/database/R2dbcConnectionFactoryAutoConfiguration.java
+++ b/src/main/java/cloud/cholewa/commons/database/R2dbcConnectionFactoryAutoConfiguration.java
@@ -39,14 +39,15 @@ public class R2dbcConnectionFactoryAutoConfiguration {
             .option(ConnectionFactoryOptions.DATABASE, databaseProperties.name())
             .option(ConnectionFactoryOptions.USER, databaseProperties.username())
             .option(ConnectionFactoryOptions.PASSWORD, databaseProperties.password())
-            .option(Option.valueOf("sslMode"), "REQUIRE")
+            .option(Option.valueOf("sslMode"), databaseProperties.sslMode())
             .build()
         );
 
         //R2dbcAutoConfiguration backs off once this bean exists, so without the pool every query -
         //and every /actuator/health call, which the health indicator answers with its own connection -
-        //opens its own physical connection. The pool name is the service name, so the r2dbc_pool_*
-        //metrics tell the services apart
+        //opens its own physical connection. The pool name only feeds the JMX object name, which is
+        //never registered here - the r2dbc_pool_* metrics are tagged with the Spring bean name by
+        //ConnectionPoolMetricsAutoConfiguration, so every service reports name="connectionFactory"
         final DatabaseProperties.Pool pool = databaseProperties.pool();
 
         return new ConnectionPool(ConnectionPoolConfiguration.builder(connectionFactory)

--- a/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+cloud.cholewa.commons.database.R2dbcConnectionFactoryAutoConfiguration

--- a/src/test/java/cloud/cholewa/commons/database/R2dbcConnectionFactoryAutoConfigurationTest.java
+++ b/src/test/java/cloud/cholewa/commons/database/R2dbcConnectionFactoryAutoConfigurationTest.java
@@ -1,0 +1,119 @@
+package cloud.cholewa.commons.database;
+
+import io.r2dbc.pool.ConnectionPool;
+import io.r2dbc.spi.ConnectionFactory;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.context.annotation.ImportCandidates;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class R2dbcConnectionFactoryAutoConfigurationTest {
+
+    private static final String[] DATABASE = {
+        "database.host=localhost",
+        "database.port=5432",
+        "database.name=dummyName",
+        "database.username=dummyUser",
+        "database.password=dummyPassword"
+    };
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+        .withConfiguration(AutoConfigurations.of(R2dbcConnectionFactoryAutoConfiguration.class));
+
+    @Test
+    void should_be_listed_as_an_auto_configuration() {
+        assertThat(ImportCandidates.load(AutoConfiguration.class, getClass().getClassLoader()).getCandidates())
+            .contains(R2dbcConnectionFactoryAutoConfiguration.class.getName());
+    }
+
+    @Test
+    void should_create_a_pooled_connection_factory_when_database_is_configured() {
+        contextRunner.withPropertyValues(DATABASE).run(context -> {
+            assertThat(context).hasSingleBean(ConnectionFactory.class);
+            //the bean name is pinned here on purpose - the back-off tests below assert its absence by name
+            assertThat(context).hasBean("connectionFactory");
+            assertThat(context.getBean(ConnectionFactory.class)).isInstanceOf(ConnectionPool.class);
+        });
+    }
+
+    @Test
+    void should_apply_default_pool_settings_when_the_pool_group_is_absent() {
+        contextRunner.withPropertyValues(DATABASE).run(context -> {
+            assertThat(context.getBean(DatabaseProperties.class).pool())
+                .isEqualTo(new DatabaseProperties.Pool(2, 4, Duration.ofSeconds(10), Duration.ofMinutes(5)));
+            assertThat(maxAllocatedSizeOf(context.getBean(ConnectionFactory.class))).isEqualTo(4);
+        });
+    }
+
+    @Test
+    void should_honour_pool_settings_from_configuration() {
+        contextRunner
+            .withPropertyValues(DATABASE)
+            .withPropertyValues(
+                "database.pool.initial-size=1",
+                "database.pool.max-size=8",
+                "database.pool.max-acquire-time=PT3S",
+                "database.pool.max-idle-time=PT1M"
+            )
+            .run(context -> {
+                assertThat(context.getBean(DatabaseProperties.class).pool())
+                    .isEqualTo(new DatabaseProperties.Pool(1, 8, Duration.ofSeconds(3), Duration.ofMinutes(1)));
+                assertThat(maxAllocatedSizeOf(context.getBean(ConnectionFactory.class))).isEqualTo(8);
+            });
+    }
+
+    @Test
+    void should_back_off_when_the_service_supplies_its_own_connection_factory() {
+        contextRunner
+            .withPropertyValues(DATABASE)
+            .withUserConfiguration(OwnConnectionFactoryConfiguration.class)
+            .run(context -> {
+                assertThat(context).hasSingleBean(ConnectionFactory.class);
+                assertThat(context).hasBean("ownConnectionFactory");
+                assertThat(context).doesNotHaveBean("connectionFactory");
+            });
+    }
+
+    @Test
+    void should_back_off_when_the_database_group_is_not_configured() {
+        contextRunner.run(context -> assertThat(context).doesNotHaveBean(ConnectionFactory.class));
+    }
+
+    @Test
+    void should_back_off_when_the_r2dbc_spi_is_missing() {
+        contextRunner
+            .withPropertyValues(DATABASE)
+            .withClassLoader(new FilteredClassLoader(ConnectionFactory.class))
+            .run(context -> assertThat(context).doesNotHaveBean("connectionFactory"));
+    }
+
+    @Test
+    void should_back_off_when_the_connection_pool_is_missing() {
+        contextRunner
+            .withPropertyValues(DATABASE)
+            .withClassLoader(new FilteredClassLoader(ConnectionPool.class))
+            .run(context -> assertThat(context).doesNotHaveBean("connectionFactory"));
+    }
+
+    private int maxAllocatedSizeOf(final ConnectionFactory connectionFactory) {
+        return ((ConnectionPool) connectionFactory).getMetrics().orElseThrow().getMaxAllocatedSize();
+    }
+
+    @Configuration
+    static class OwnConnectionFactoryConfiguration {
+
+        @Bean
+        ConnectionFactory ownConnectionFactory() {
+            return mock(ConnectionFactory.class);
+        }
+    }
+}

--- a/src/test/java/cloud/cholewa/commons/database/R2dbcConnectionFactoryAutoConfigurationTest.java
+++ b/src/test/java/cloud/cholewa/commons/database/R2dbcConnectionFactoryAutoConfigurationTest.java
@@ -72,6 +72,32 @@ class R2dbcConnectionFactoryAutoConfigurationTest {
     }
 
     @Test
+    void should_reject_a_configuration_missing_the_mandatory_properties() {
+        contextRunner.withPropertyValues("database.host=localhost").run(context -> {
+            assertThat(context).hasFailed();
+            //the point of the validation: the failure names the properties, unlike the raw
+            //"value must not be null" that ConnectionFactoryOptions would throw
+            assertThat(context.getStartupFailure())
+                .hasStackTraceContaining("port")
+                .hasStackTraceContaining("username");
+        });
+    }
+
+    @Test
+    void should_default_the_ssl_mode_to_require() {
+        contextRunner.withPropertyValues(DATABASE).run(context ->
+            assertThat(context.getBean(DatabaseProperties.class).sslMode()).isEqualTo("REQUIRE"));
+    }
+
+    @Test
+    void should_pass_the_ssl_mode_on_to_the_driver() {
+        contextRunner
+            .withPropertyValues(DATABASE)
+            .withPropertyValues("database.ssl-mode=not-a-mode")
+            .run(context -> assertThat(context).hasFailed());
+    }
+
+    @Test
     void should_back_off_when_the_service_supplies_its_own_connection_factory() {
         contextRunner
             .withPropertyValues(DATABASE)


### PR DESCRIPTION
Extracts the R2DBC connection configuration that `database-service`, `water-service` and
`heating-service` each carry as their own `DbConfig` + `DatabaseProperties`, so a
database-backed service no longer copies it. Ships as an auto-configuration rather than a
class to import.

## What is added

- `DatabaseProperties` — `@ConfigurationProperties("database")` over the connection details,
  `sslMode` and a nested `Pool` record. The connection details are `@Validated`:
  `ConnectionFactoryOptions` rejects a null with a message that does not name the property,
  so a half-configured consumer would otherwise get a bare `value must not be null`.
- `R2dbcConnectionFactoryAutoConfiguration` — builds the PostgreSQL `ConnectionFactory` and
  wraps it in an `io.r2dbc.pool.ConnectionPool` with `@Bean(destroyMethod = "dispose")`.
- Registration in `META-INF/spring/…AutoConfiguration.imports`, ordered
  `@AutoConfiguration(before = R2dbcAutoConfiguration.class)` — Boot's own factory is
  `@ConditionalOnMissingBean` too, so without the ordering the winner is undefined.

## Why the guards

The release has to stay additive for the six consumers without R2DBC and for anyone
configuring their database through `spring.r2dbc.*`:

- `@ConditionalOnClass({ConnectionFactory.class, ConnectionPool.class})` — both, because
  `r2dbc-pool` does not come with `spring-boot-r2dbc`; in the services it arrives through
  `spring-boot-data-r2dbc`, so a consumer can have the SPI without the pool.
- `@ConditionalOnProperty(prefix = "database", name = "host")` — without it, upgrading would
  break the startup of a consumer that has R2DBC on the classpath but no `database.*` group.
- `@ConditionalOnMissingBean` — a service can still supply its own factory.

The r2dbc dependencies are `provided`, which is safe here (unlike the `spring-tx` case
documented in `CLAUDE.md`) precisely because `@ConditionalOnClass` is read via ASM.

## Notes for the adopting services

- Pool size stays per-service configuration — the managed database allows 22 backend
  connections in total. **A service replacing its own `DbConfig` must set
  `database.pool.max-size` explicitly**; the default of `4` is sized for a new service and
  would silently shrink heating (8) and database (6).
- `@EnableR2dbcRepositories` must **not** move here: with no `basePackages` the scan base is
  the annotated class's package, so no service repository would be found, and its mere
  presence makes `R2dbcRepositoriesAutoConfiguration` back off. It stays in the service.
- `heating-service` injects the factory by type, so renaming its bean from
  `postgresConnectionFactory` to `connectionFactory` is safe — but that also renames the
  `name` tag of its `r2dbc_pool_*` metrics, which `ConnectionPoolMetricsAutoConfiguration`
  takes from the Spring bean name. No dashboard queries those series today.

## Tests

`R2dbcConnectionFactoryAutoConfigurationTest` drives the auto-configuration with
`ApplicationContextRunner`: every guard, the validation, the ssl mode reaching the driver,
and the pool defaults and overrides asserted on the built pool via
`getMetrics().getMaxAllocatedSize()`. `ImportCandidates` asserts the class is really listed
in the `.imports` file — run it with `clean`, since `mvn test` alone keeps a stale copy of
that resource in `target/classes`.

Also loads Mockito as a real `-javaagent` instead of letting it self-attach, which the JDK
already warns about and will disallow. The surefire `argLine` uses `@{argLine}` late
replacement so it composes with the jacoco agent that `sonar.yml` sets from the command line.

`mvn clean verify`: 32 tests, enforcer and `tidy:check` green. Coverage path verified with
the exact `sonar.yml` command.

Part of HAS-146; the three services adopt 1.3.0 and delete their local copies in the same
task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
