### PR TITLE
HAS-146: ship the configuration metadata for the database.* group

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,10 +92,17 @@ snippet).
   null`. `sslMode` is a property (`database.ssl-mode`, default `REQUIRE`) rather than a
   constant, so a consumer on a database without TLS is not forced to declare its own
   `ConnectionFactory` bean just to change one option.
+- `spring-boot-configuration-processor` is on the classpath in `optional` scope so the jar
+  ships `META-INF/spring-configuration-metadata.json` for the `database.*` group. Without it
+  a consumer that has the processor itself loses the completion and validation it had for
+  its own local properties class and starts hand-maintaining
+  `additional-spring-configuration-metadata.json` — `heating-service` did exactly that.
 - `@EnableR2dbcRepositories` must **not** move into this package: with no `basePackages` the
   scan base is the annotated class's package, so no consumer repository would be found, and
-  its mere presence makes `R2dbcRepositoriesAutoConfiguration` back off. It stays in the
-  service.
+  its mere presence makes `R2dbcRepositoriesAutoConfiguration` back off. In the consumer the
+  better move is to drop the annotation altogether and let that auto-configuration scan from
+  the application class's package: put on the application class it leaks into `@WebFluxTest`
+  slices, which then fail on the missing `r2dbcEntityTemplate` (hit in `heating-service`).
 - The nested `Pool` record needs a bare `@DefaultValue` on the `pool` component itself, not
   only on its fields — otherwise a missing `database.pool` group binds to `null` and the pool
   build NPEs.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The artifact is published to GitHub Packages:
 <dependency>
     <groupId>cloud.cholewa</groupId>
     <artifactId>cholewa-commons</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.1</version>
 </dependency>
 ```
 
@@ -138,15 +138,20 @@ database:
 
 The five connection properties are mandatory and validated at bind time, so a missing one
 fails the startup with a message naming it rather than a bare `value must not be null`.
+The jar ships the configuration metadata for the whole group, so an IDE completes and
+type-checks these keys without the consumer declaring anything.
 
 > **Replacing an existing `DbConfig`?** Set `database.pool.max-size` explicitly in the same
 > change. The default of `4` is sized for a new service, and a service whose own pool was
 > larger silently shrinks to it — under load the callers then time out on
 > `max-acquire-time` instead of queueing on the connections they used to have.
 
-Repositories are deliberately **not** enabled here — keep `@EnableR2dbcRepositories` on a
-class in the service (or rely on Boot's own auto-configuration), so the scan starts from the
-service's package and not from this library's.
+Repositories are deliberately **not** enabled here, so the scan starts from the service's
+package and not from this library's. The simplest option in the service is to declare
+nothing and let Boot's `R2dbcRepositoriesAutoConfiguration` scan from the application class's
+package. If you do want `@EnableR2dbcRepositories`, put it on a dedicated `@Configuration` —
+on the application class it leaks into `@WebFluxTest` slices, which then fail on the missing
+`r2dbcEntityTemplate`.
 
 The bean is named `connectionFactory`, which is also the `name` tag of the `r2dbc_pool_*`
 metrics when Actuator and a Micrometer registry are on the classpath.

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,14 @@
 			<artifactId>r2dbc-pool</artifactId>
 			<scope>provided</scope>
 		</dependency>
+		<!-- generates META-INF/spring-configuration-metadata.json for DatabaseProperties, so a
+             consumer gets completion and validation for the database.* group instead of
+             hand-maintaining additional-spring-configuration-metadata.json -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>


### PR DESCRIPTION
Follow-up to #25. `DatabaseProperties` moved into this library, but the library did not ship
configuration metadata for it — so a consumer that has `spring-boot-configuration-processor`
itself lost the completion and validation it used to have for its own local properties class.
`heating-service` hit this while adopting 1.3.0 and started hand-maintaining
`additional-spring-configuration-metadata.json`, incompletely and with `database.pool.max-size`
typed as a `String`.

Adding the processor in `optional` scope makes the jar carry
`META-INF/spring-configuration-metadata.json` with the whole group, types and defaults
included:

```
database.host                   java.lang.String
database.port                   java.lang.Integer
database.name                   java.lang.String
database.username               java.lang.String
database.password               java.lang.String
database.ssl-mode               java.lang.String    = REQUIRE
database.pool.initial-size      java.lang.Integer   = 2
database.pool.max-size          java.lang.Integer   = 4
database.pool.max-acquire-time  java.time.Duration  = PT10S
database.pool.max-idle-time     java.time.Duration  = PT5M
```

`optional` keeps it off every consumer's classpath — it is only needed while compiling this
module.

## Docs correction

Both the README and `CLAUDE.md` recommended keeping `@EnableR2dbcRepositories` "on a class in
the service (or rely on Boot's own auto-configuration)", which put the worse option first.
`@WebFluxTest` bootstraps from the `@SpringBootConfiguration` class and applies its
annotations, so the annotation on the application class leaks into every web slice, which then
fails on the missing `r2dbcEntityTemplate` — three slice tests in `heating-service` broke on
exactly that. The guidance now leads with declaring nothing and letting
`R2dbcRepositoriesAutoConfiguration` scan from the application package, and points at a
dedicated `@Configuration` as the explicit alternative.

README installation snippet pinned to 1.3.1 in this PR, per the convention set in #25.

`mvn clean verify`: 32 tests, enforcer and `tidy:check` green; metadata confirmed inside the
built jar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
